### PR TITLE
Generate /slides index dynamically and reuse 404.html for misses

### DIFF
--- a/functions/slides/[[path]].js
+++ b/functions/slides/[[path]].js
@@ -1,7 +1,11 @@
 /**
  * Serves /slides/* from the R2 bucket bound as `SLIDES`
  * (configured in the Cloudflare dashboard: Pages > Settings > Bindings).
+ * "/slides/" itself is a dynamically generated listing of the bucket's
+ * top-level prefixes, cached at the edge.
  */
+
+const INDEX_CACHE_CONTROL = "public, max-age=60, s-maxage=600";
 
 /**
  * Maps a request pathname to an R2 object key. The "/slides" prefix is
@@ -18,13 +22,96 @@ function resolveKey(pathname) {
   return key;
 }
 
+function escapeHtml(text) {
+  const replacements = {
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+  };
+  return text.replace(/[&<>"]/g, (c) => replacements[c]);
+}
+
+function renderIndex(names) {
+  const list =
+    names.length === 0
+      ? "<p>No slides yet.</p>"
+      : `<ul>
+          ${names
+            .map(
+              (name) =>
+                `<li><a href="/slides/${encodeURIComponent(name)}/">${escapeHtml(name)}</a></li>`,
+            )
+            .join("\n          ")}
+        </ul>`;
+
+  return `<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <title>azrsh's slides</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" href="/favicon.ico" />
+    <link rel="stylesheet" href="/style.css" />
+  </head>
+  <body>
+    <div class="container">
+      <header>
+        <h1>Slides</h1>
+      </header>
+      <main>
+        ${list}
+      </main>
+      <footer>
+        <small>© 2025 @azrsh</small>
+      </footer>
+    </div>
+  </body>
+</html>
+`;
+}
+
+async function serveIndex(context) {
+  const cache = caches.default;
+  // Normalize "/slides" and "/slides/" to a single cache entry.
+  const cacheKey = new Request(new URL("/slides/", context.request.url));
+  const cached = await cache.match(cacheKey);
+  if (cached) return cached;
+
+  const listing = await context.env.SLIDES.list({ delimiter: "/" });
+  const names = listing.delimitedPrefixes.map((prefix) => prefix.slice(0, -1));
+  const response = new Response(renderIndex(names), {
+    headers: {
+      "content-type": "text/html; charset=utf-8",
+      "cache-control": INDEX_CACHE_CONTROL,
+    },
+  });
+  context.waitUntil(cache.put(cacheKey, response.clone()));
+  return response;
+}
+
+async function notFound(context) {
+  const page = await context.env.ASSETS.fetch(
+    new URL("/404.html", context.request.url),
+  );
+  return new Response(page.body, {
+    status: 404,
+    headers: {
+      "content-type":
+        page.headers.get("content-type") ?? "text/plain; charset=utf-8",
+    },
+  });
+}
+
 export async function onRequestGet(context) {
   const { pathname } = new URL(context.request.url);
-  const key = resolveKey(pathname);
+  if (pathname === "/slides" || pathname === "/slides/") {
+    return serveIndex(context);
+  }
 
-  const object = await context.env.SLIDES.get(key);
+  const object = await context.env.SLIDES.get(resolveKey(pathname));
   if (!object) {
-    return new Response("Not Found", { status: 404 });
+    return notFound(context);
   }
 
   const headers = new Headers();


### PR DESCRIPTION
The /slides/ root now lists the R2 bucket's top-level prefixes, cached at the edge (s-maxage=600) via the Cache API. Missing objects respond with public/404.html instead of a bare message.